### PR TITLE
Potential fix for code scanning alert no. 35: Database query built from user-controlled sources

### DIFF
--- a/backend/src/controller/dishController.js
+++ b/backend/src/controller/dishController.js
@@ -55,13 +55,22 @@ export class DishController {
       const { id } = req.params
       const patch = req.body
 
-      if (Object.keys(patch).length === 0) {
-        return res.status(400).json({ message: 'No hay campos para cambiar.' })
+      // Only allow specific fields to be updated
+      const allowedFields = ['name', 'description', 'price', 'category', 'ingredients', 'image'];
+      const sanitizedPatch = {};
+      for (const key of Object.keys(patch)) {
+        if (allowedFields.includes(key) && !key.startsWith('$')) {
+          sanitizedPatch[key] = patch[key];
+        }
+      }
+
+      if (Object.keys(sanitizedPatch).length === 0) {
+        return res.status(400).json({ message: 'No hay campos válidos para cambiar.' });
       }
 
       const result = await Dish.updateOne(
         { _id: id },
-        { $set: patch }
+        { $set: sanitizedPatch }
       )
       if (result.nModified === 0) {
         return res.status(404).json({ message: 'No se encontraron platos con el ID proporcionado o no se han hecho modificaciones.' })


### PR DESCRIPTION
Potential fix for [https://github.com/AndresPatarroyo1517/ciprianis-ristorante/security/code-scanning/35](https://github.com/AndresPatarroyo1517/ciprianis-ristorante/security/code-scanning/35)

To prevent a NoSQL injection or unintended database updates, the patch object (`req.body`) should be sanitized or filtered so that only permitted fields are allowed to be updated, and special MongoDB operators (i.e., keys beginning with `$`) are disallowed from being set via the patch. A best-practice fix is to create an explicit allow-list of updatable fields (e.g., name, description, price, category, ingredients, image), iterate over the incoming patch, and construct a new object containing only allowed fields with values of permitted types. This sanitization should occur directly in the `updateDish` method, before passing the data to `Dish.updateOne`. It is also prudent to reject requests if any of the attempted fields are not in the allow-list, to alert clients of invalid attempts. No new imports are needed; use vanilla JS to filter the keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
