### PR TITLE
Potential fix for code scanning alert no. 34: Database query built from user-controlled sources

### DIFF
--- a/backend/src/controller/auth.js
+++ b/backend/src/controller/auth.js
@@ -80,7 +80,7 @@ export class AuthController {
     try {
       schemaLoginValidation.parse(req.body)
       const { username, password, stayLoggedIn } = req.body
-      const user = await User.findOne({ username })
+      const user = await User.findOne({ username: { $eq: username } })
       if (!user) throw new Error('El usuario no existe.')
       const validPassword = await bcrypt.compare(password, user.password)
       if (!validPassword) throw new Error('La contraseña es incorrecta.')


### PR DESCRIPTION
Potential fix for [https://github.com/AndresPatarroyo1517/ciprianis-ristorante/security/code-scanning/34](https://github.com/AndresPatarroyo1517/ciprianis-ristorante/security/code-scanning/34)

To fix this problem, we should ensure that user-controlled data provided as a value in a MongoDB query is *always* interpreted as a literal, and cannot be interpreted as a query object. Instead of `User.findOne({ username })`, use `User.findOne({ username: { $eq: username } })` to guarantee that MongoDB performs a simple equality check, regardless of what the incoming value is.  

Specifically, in `backend/src/controller/auth.js`, replace:
```js
const user = await User.findOne({ username })
```
with:
```js
const user = await User.findOne({ username: { $eq: username } })
```
Apply the same logic anywhere else in this file where similarly constructed query objects from user-supplied input might be used (such as in `validateExist` function; though note that there, the data originates from validated schema).

No extra imports or method definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
