### PR TITLE
Potential fix for code scanning alert no. 32: Database query built from user-controlled sources

### DIFF
--- a/backend/src/controller/auth.js
+++ b/backend/src/controller/auth.js
@@ -20,8 +20,8 @@ const schemaLoginValidation = z.object({
 })
 
 const validateExist = async (username, email) => {
-  const userExist = await User.findOne({ username })
-  const emailExist = await User.findOne({ email })
+  const userExist = await User.findOne({ username: { $eq: username } })
+  const emailExist = await User.findOne({ email: { $eq: email } })
   if (emailExist) {
     throw new Error('El correo electrónico ya está en uso.')
   }


### PR DESCRIPTION
Potential fix for [https://github.com/AndresPatarroyo1517/ciprianis-ristorante/security/code-scanning/32](https://github.com/AndresPatarroyo1517/ciprianis-ristorante/security/code-scanning/32)

To fix this NoSQL injection vulnerability, we need to ensure that the value used for the `username` field in the query is strictly interpreted as a literal value (not as an operator object). The best way in modern MongoDB/Mongoose usage is to use the `$eq` operator when performing equality checks on potentially user-controlled input. This forces MongoDB to treat the input as a strict value comparison, even if the input is an object. 

Change the query in `validateExist` from:
```js
await User.findOne({ username })
```
to:
```js
await User.findOne({ username: { $eq: username } })
```

Do the same for the email field:
```js
await User.findOne({ email })
```
to:
```js
await User.findOne({ email: { $eq: email } })
```

No additional imports are needed to use the `$eq` operator. Only a small change is required in the `validateExist` function within `backend/src/controller/auth.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
