### PR TITLE
Potential fix for code scanning alert no. 31: Missing CSRF middleware

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3,6 +3,7 @@ import mongoose from 'mongoose'
 import dotenv from 'dotenv'
 import cors from 'cors'
 import cookieParser from 'cookie-parser'
+import lusca from 'lusca'
 import authRoutes from './src/routes/authRoutes.js'
 import dishRoutes from './src/routes/dishRoutes.js'
 import orderRoutes from './src/routes/orderRoutes.js'
@@ -14,6 +15,7 @@ const app = express()
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
 app.use(cookieParser())
+app.use(lusca.csrf())
 app.use(cors({
   origin: (origin, callback) => {
     if (process.env.ACCEPTED_ORIGINS.includes(origin)) {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,8 @@
     "express-rate-limit": "^7.4.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.5.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "lusca": "^1.7.0"
   },
   "eslintConfig": {
     "extends": "standard"


### PR DESCRIPTION
Potential fix for [https://github.com/AndresPatarroyo1517/ciprianis-ristorante/security/code-scanning/31](https://github.com/AndresPatarroyo1517/ciprianis-ristorante/security/code-scanning/31)

To properly mitigate the CSRF vulnerability, a CSRF protection middleware should be added soon after cookie and body parsing but before sensitive routes are mounted. In `backend/index.js`, after `app.use(cookieParser())` and before the route mounting with `app.use('/auth', ...)`, include a CSRF protection middleware. The recommended library is `lusca`, which works well with Express and session/cookie authentication. You need to:  
1. Install `lusca` (`npm install lusca`) if not present.
2. Import `lusca` in the file.
3. Configure CSRF protection by using `app.use(lusca.csrf())` after session/cookie parsers but before mounting sensitive routes.
4. Optionally, provide meaningful error handling for CSRF token mismatch/rejection (can be added later).  
No change to existing functionality or route structure is required. Only import and use the CSRF protection middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
